### PR TITLE
[SPSDK-5] Fix handling UID in Unlock commands

### DIFF
--- a/spsdk/image/__init__.py
+++ b/spsdk/image/__init__.py
@@ -10,8 +10,8 @@
 
 from .bee import BeeRegionHeader, BeeKIB, BeeProtectRegionBlock, BeeFacRegion
 from .commands import EnumWriteOps, EnumCheckOps, EnumCertFormat, EnumInsKey, EnumAuthDat, EnumEngine, \
-                      EnumItm, CmdWriteData, CmdCheckData, CmdNop, CmdSet, CmdInitialize, CmdUnlock, CmdUnlockSNVS,\
-                      CmdInstallKey, CmdAuthData
+                      EnumItm, CmdWriteData, CmdCheckData, CmdNop, CmdSet, CmdInitialize, CmdUnlock, \
+                      CmdUnlockCAAM, CmdUnlockOCOTP, CmdUnlockSNVS, CmdInstallKey, CmdAuthData
 from .segments import SegIVT2, SegIVT3a, SegIVT3b, SegBDT, SegAPP, SegDCD, SegCSF, PaddingFCB, FlexSPIConfBlockFCB
 from .secret import SrkTable, SrkItem, CertificateImg, Signature, MAC, SecretKeyBlob, EnumAlgorithm
 from .images import parse, BootImgRT, BootImg2, BootImg3a, BootImg3b, BootImg4, EnumAppType
@@ -69,6 +69,8 @@ __all__ = [
     'CmdInstallKey',
     'CmdAuthData',
     'CmdUnlock',
+    'CmdUnlockCAAM',
+    'CmdUnlockOCOTP',
     'CmdUnlockSNVS',
     # Elements
     'EnumWriteOps',


### PR DESCRIPTION
Two more specialized Unlock classes were missing (using CAAM and OCOTP engines)
The UID is now expected/processed only if it's needed.
There's a new static method: CmdUnlock.need_uid(engine, features) that returns True is UID is needed/expected

This branch/pull request comes from issue #5 