### PR TITLE
BootImg2: CSF parsing improvement

### DIFF
--- a/spsdk/image/images.py
+++ b/spsdk/image/images.py
@@ -25,7 +25,7 @@ from spsdk.utils.misc import align, align_block, extend_block
 from .commands import CmdAuthData, CmdInstallKey
 from .commands import EnumInsKey, EnumCertFormat, EnumAlgorithm, EnumAuthDat, EnumEngine
 from .header import Header, Header2, UnparsedException
-from .misc import read_raw_data, read_raw_segment
+from .misc import read_raw_data, read_raw_segment, NotEnoughBytesException
 from .secret import Signature, CertificateImg, MAC, SrkTable
 from .segments import SegTag, SegIVT2, SegBDT, SegAPP, SegDCD, SegCSF, SegIVT3a, SegIVT3b, SegBDS3a, SegBDS3b, \
     SegBIC1, AbstractFCB, FlexSPIConfBlockFCB, PaddingFCB, SegBEE
@@ -1089,8 +1089,11 @@ class BootImg2(BootImgBase):
         # Parse CSF
         if obj.ivt.csf_address:
             csf_start = start_index + (obj.ivt.csf_address - obj.ivt.ivt_address)
-            obj.csf = SegCSF.parse(read_raw_segment(stream, SegTag.CSF, csf_start))
-            # obj.csf.padding = csf_start + obj.csf.size
+            try:
+                obj.csf = SegCSF.parse(read_raw_segment(stream, SegTag.CSF, csf_start))
+                # obj.csf.padding = csf_start + obj.csf.size
+            except NotEnoughBytesException:
+                pass
 
         return obj
 

--- a/spsdk/image/images.py
+++ b/spsdk/image/images.py
@@ -1090,8 +1090,8 @@ class BootImg2(BootImgBase):
         if obj.ivt.csf_address:
             csf_start = start_index + (obj.ivt.csf_address - obj.ivt.ivt_address)
             try:
-                obj.csf = SegCSF.parse(read_raw_segment(stream, SegTag.CSF, csf_start))
-                # obj.csf.padding = csf_start + obj.csf.size
+                obj.csf = SegCSF.parse(read_raw_data(stream, cls.CSF_SIZE, csf_start))
+                obj.csf.padding = cls.CSF_SIZE - obj.csf.size
             except NotEnoughBytesException:
                 pass
 

--- a/spsdk/image/misc.py
+++ b/spsdk/image/misc.py
@@ -15,6 +15,18 @@ from typing import Union
 from .header import Header
 
 
+class RawDataException(Exception):
+    "Raw data read failed"
+
+
+class StreamReadFailed(RawDataException):
+    "read_raw_data could not read stream"
+
+
+class NotEnoughBytesException(RawDataException):
+    "read_raw_data could not read enough data"
+
+
 def size_fmt(num: Union[float, int], use_kibibyte: bool = True) -> str:
     """Size format."""
     base, suffix = [(1000., 'B'), (1024., 'iB')][use_kibibyte]
@@ -51,10 +63,10 @@ def read_raw_data(stream: Union[io.BufferedReader, io.BytesIO], length: int, ind
     try:
         data = stream.read(length)
     except Exception:
-        raise Exception(" stream.read() failed, requested {} bytes".format(length))
+        raise StreamReadFailed(" stream.read() failed, requested {} bytes".format(length))
 
     if len(data) != length:
-        raise Exception(" Could not read enough bytes, expected {}, found {}".format(length, len(data)))
+        raise NotEnoughBytesException(" Could not read enough bytes, expected {}, found {}".format(length, len(data)))
 
     if no_seek:
         stream.seek(-length, SEEK_CUR)


### PR DESCRIPTION
* Do not bail out if CSF address is given but CSF is not present
* Read CSF command data into a CSF parsing buffer

u-boot's mkimage and possibly other tools want to be nice
to people still using CST to sign their images and provide
pre-populated IVT with a CSF address there, but the file does
not contain the CSF itself. We should not abort on short read
in this case.

Copied BootImgRT solution to read 4096 bytes of CSF into
the CSF parsing buffer. Two improvements possible: make it
generic for all images and also we could read the stream
on-demand whenever additional CSF data segments are needed.