### PR TITLE
Add missing timezone in tests

### DIFF
--- a/spsdk/utils/crypto/common.py
+++ b/spsdk/utils/crypto/common.py
@@ -7,7 +7,7 @@
 
 """Common cryptographic functions."""
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cryptography.hazmat.primitives.asymmetric import utils
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicNumbers
@@ -83,7 +83,7 @@ def pack_timestamp(value: datetime) -> int:
     :return: number of milliseconds since 1.1.2000  00:00:00; 64-bit integer
     """
     assert isinstance(value, datetime)
-    start = datetime(2000, 1, 1, 0, 0, 0, 0).timestamp()
+    start = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp()
     result = int((value.timestamp() - start) * 1000000)
     assert 0 <= result <= 0xFFFFFFFFFFFFFFFF
     return result
@@ -98,7 +98,7 @@ def unpack_timestamp(value: int) -> datetime:
     """
     assert isinstance(value, int)
     assert 0 <= value <= 0xFFFFFFFFFFFFFFFF
-    start = int(datetime(2000, 1, 1, 0, 0, 0, 0).timestamp() * 1000000)
+    start = int(datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp() * 1000000)
     return datetime.fromtimestamp((start + value) / 1000000)
 
 

--- a/tests/mcu_examples/test_rt10xx.py
+++ b/tests/mcu_examples/test_rt10xx.py
@@ -842,7 +842,7 @@ def test_sb(cpu_params: CpuParams) -> None:
     :param cpu_params: processor specific parameters of the test
     """
     # timestamp is fixed for the test, do not not for production
-    timestamp = datetime(year=2020, month=4, day=24, hour=16, minute=33, second=32)
+    timestamp = datetime(year=2020, month=4, day=24, hour=15, minute=33, second=32, tzinfo=timezone.utc)
 
     # load application to add into SB
     img_name = f'{cpu_params.board}_iled_blinky_ext_FLASH_unsigned_nopadding'
@@ -879,7 +879,7 @@ def test_sb_multiple_sections(cpu_params: CpuParams) -> None:
         return  # this test case is supported only for RT1050 and RT1060
 
     # timestamp is fixed for the test, do not not for production
-    timestamp = datetime(year=2020, month=4, day=24, hour=16, minute=33, second=32)
+    timestamp = datetime(year=2020, month=4, day=24, hour=15, minute=33, second=32, tzinfo=timezone.utc)
 
     # load application to add into SB
     img_name = f'{cpu_params.board}_iled_blinky_ext_FLASH_unsigned_nofcb'

--- a/tests/mcu_examples/test_rt5xx.py
+++ b/tests/mcu_examples/test_rt5xx.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from struct import pack
 from time import sleep
 from typing import List, Optional, Tuple
@@ -625,7 +625,7 @@ def test_sb_unsigned_keystore(data_dir: str, subdir: str, image_name: str) -> No
         sbkek_str = f.readline()
 
     adv_params =SBV2xAdvancedParams(dek=b'\xA0' * 32, mac=b'\x0B' * 32, nonce=bytes(16),
-                                    timestamp=datetime(2020, month=1, day=31))
+                                    timestamp=datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc))
     # create boot image
     boot_image = BootImageV21(
         kek=bytes.fromhex(sbkek_str),
@@ -696,7 +696,7 @@ def test_sb_unsigned_otp(data_dir: str, subdir: str, image_name: str) -> None:
     sbkek = KeyStore.derive_sb_kek_key(bytes.fromhex(MASTER_KEY))
 
     adv_params = SBV2xAdvancedParams(dek=b'\xA0' * 32, mac=b'\x0B' * 32, nonce=bytes(16),
-                                     timestamp=datetime(2020, month=1, day=31))
+                                     timestamp=datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc))
 
     # create SB file boot image
     boot_image = BootImageV21(
@@ -760,7 +760,7 @@ def test_sb_signed_encr_keystore(data_dir: str, subdir: str, image_name: str) ->
         sbkek_str = f.readline()
 
     adv_params = SBV2xAdvancedParams(dek=b'\xA0' * 32, mac=b'\x0B' * 32, nonce=bytes(16),
-                                     timestamp=datetime(2020, month=1, day=31))
+                                     timestamp=datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc))
 
     # create SB file boot image
     boot_image = BootImageV21(
@@ -828,7 +828,7 @@ def test_sb_otfad_keystore(data_dir: str, subdir: str, image_name: str, secure: 
     key_store = get_keystore(data_dir)
 
     adv_params = SBV2xAdvancedParams(dek=b'\xA0' * 32, mac=b'\x0B' * 32, nonce=bytes(16),
-                                     timestamp=datetime(2020, month=1, day=31))
+                                     timestamp=datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc))
 
     # create SB file boot image
     boot_image = BootImageV21(
@@ -942,7 +942,7 @@ def test_sb_otfad_otp(data_dir: str, subdir: str, image_name: str, secure: bool)
     key_store = get_keystore(data_dir)
 
     adv_params = SBV2xAdvancedParams(dek=b'\xA0' * 32, mac=b'\x0B' * 32, nonce=bytes(16),
-                                     timestamp=datetime(2020, month=1, day=31))
+                                     timestamp=datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc))
 
     # create SB file boot image
     boot_image = BootImageV21(

--- a/tests/sbfile/test_sbfile_image.py
+++ b/tests/sbfile/test_sbfile_image.py
@@ -7,7 +7,7 @@
 
 import os
 from binascii import unhexlify
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -177,7 +177,7 @@ def test_sb2x_builder(data_dir: str, sb_minor_ver: int, sign_bits: int, otfad: b
     mac_value = b'\x0B' * 32
 
     # this is hardcoded in the test; if not specified, current value will be used
-    timestamp = datetime.fromtimestamp(int(datetime(2020, month=1, day=31).timestamp()))
+    timestamp = datetime.fromtimestamp(int(datetime(2020, month=1, day=31, hour=0, tzinfo=timezone.utc).timestamp()))
     adv_params = SBV2xAdvancedParams(dek=dek_value, mac=mac_value, nonce=bytes(16), timestamp=timestamp)
 
     # create boot image


### PR DESCRIPTION
Tests for objects that contain the NXP version of the timestamp (number of milliseconds since Jan 1, 2000) were failing due to missing information about the time zone. The problem was observed in multiple environments (not only those specified in #17 )
The issue was fixed by adding the UTC timezone to functions creating/parsing the NXP timestamp and test that relay on a consistent timestamp (for reproducibility).