### PR TITLE
Make blhost.py compatible with click >= 8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astunparse>=1.6,<2
 bincopy<17.11
 bitstring>=3.1,<3.2
 click-option-group>=0.3.0,<0.6
-click>=7.1,<8
+click>=7.1,<8.2
 colorama>=0.4.4,<1
 commentjson>=0.9,<1
 crcmod==1.7

--- a/spsdk/apps/blhost.py
+++ b/spsdk/apps/blhost.py
@@ -127,7 +127,7 @@ def main(
 
     # print help for get-property if property tag is 0 or 'list-properties'
     if ctx.invoked_subcommand == "get-property":
-        args = click.get_os_args()
+        args = sys.argv[1:]
         # running this via pytest changes the args to a single arg, in that case skip
         if len(args) > 1 and "get-property" in args:
             tag_str = args[args.index("get-property") + 1]
@@ -136,7 +136,7 @@ def main(
                 ctx.exit(0)
 
     # if --help is provided anywhere on commandline, skip interface lookup and display help message
-    if "--help" not in click.get_os_args():
+    if "--help" not in sys.argv[1:]:
         ctx.obj = {
             "interface": get_interface(
                 module="mboot", port=port, usb=usb, timeout=timeout, lpcusbsio=lpcusbsio


### PR DESCRIPTION
spsdk/apps/blhost.py:
Remove all occurences of `click.get_os_args()` as it has been removed in
click 8.1 (see
https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0) and
replace it with `sys.argv[1:]`.

requirements.txt:
Increase the upper version boundary for click to < 8.2.

Fixes #44 

Signed-off-by: David Runge <dave@sleepmap.de>