### PR TITLE
Fix the use of pyyaml's load in tests

### DIFF
--- a/tests/nxpcertgen/test_certgen.py
+++ b/tests/nxpcertgen/test_certgen.py
@@ -12,6 +12,7 @@ from typing import List
 
 import pytest
 import yaml
+from yaml import Loader
 from click.testing import CliRunner
 
 from spsdk import SPSDKError
@@ -270,6 +271,6 @@ def test_generate_template(tmpdir):
         assert result.exit_code == 0
         assert os.path.isfile(template)
         with open(template) as f:
-            data = yaml.load(f)
+            data = yaml.load(f, Loader=Loader)
         # there should be at least 5 items in the template
         assert len(data) > 5


### PR DESCRIPTION
tests/nxpcertgen/test_certgen.py:
Provide a yaml.Loader to the call of yaml.load.

Fixes #45 